### PR TITLE
Fix SDk for Crashlytics

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Fix line endings on gradlew
         run: sed -i 's/\r$//' gradlew
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Cache Gradle
         uses: actions/cache@v3


### PR DESCRIPTION
La version escrita en el android,yml es menor a la version necesaria para probar crashlytics